### PR TITLE
excluded arm64 architecture for iOS simulator 

### DIFF
--- a/razorpay-pod.podspec
+++ b/razorpay-pod.podspec
@@ -37,6 +37,9 @@ helps businesses accepts online payments via Credit Card, Debit Card, Net bankin
   s.exclude_files = 'UpdatePod.sh'
 
   s.vendored_frameworks = 'Pod/Razorpay.framework'
+  
+  s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+  s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
   # s.prepare_command = <<-CMD
   #   chmod 777 ./Pod/SelectDefaultXcode.sh
   #   sh ./Pod/SelectDefaultXcode.sh


### PR DESCRIPTION
Linking issue fixed by excluding arm64 arch for iOS simulator