### PR TITLE
ISS-934772 : fix: Add missing test target to Package.swift for SPM code coverage

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,6 +27,11 @@ let package = Package(
         .binaryTarget(
             name: "Razorpay",
             path: "Pod/Razorpay.xcframework"
+        ),
+        .testTarget(
+            name: "RazorpayCheckoutTests",
+            dependencies: ["RazorpayCheckout"],
+            path: "RazorpayCheckout/Tests/RazorpayCheckoutTests"
         )
     ],
     swiftLanguageVersions: [.v5]


### PR DESCRIPTION
- Add .testTarget for RazorpayCheckoutTests to enable test discovery
- Fixes 0% code coverage issue when merchants integrate via Swift Package Manager
- Tests were present but not declared in Package.swift targets array

Resolves merchant reports of missing test coverage in SPM integration.

