### PR TITLE
chore: use optimistic version constraint for razorpay-core-pod depend…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v1.5.3](https://github.com/razorpay/razorpay-pod/tree/v1.5.3) (2026-01-06)
+
+**Changes:**
+
+- Updated `razorpay-core-pod` dependency to use optimistic version constraint (`~> 1.0.3`) for better compatibility with patch releases
+
 ## [v1.1.13](https://github.com/razorpay/razorpay-pod/tree/v1.1.13) (2021-05-14)
 
 **Implemented enhancements:**

--- a/razorpay-pod.podspec
+++ b/razorpay-pod.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "razorpay-pod"
-  s.version          = '1.5.2'
+  s.version          = '1.5.3'
   s.summary          = "CocoaPod implementation of Razorpay's Payment SDK"
 
 # This description is used to generate tags and improve search results.
@@ -37,7 +37,7 @@ helps businesses accepts online payments via Credit Card, Debit Card, Net bankin
   s.exclude_files = 'UpdatePod.sh'
 
   s.vendored_frameworks = 'Pod/RazorpayStandard.xcframework'
-  s.dependency 'razorpay-core-pod' , '1.0.3'
+  s.dependency 'razorpay-core-pod' , '~> 1.0.3'
   
   #s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
   #s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }


### PR DESCRIPTION
…ency

chore: use optimistic version constraint for razorpay-core-pod dependency

Updated razorpay-core-pod dependency from exact version '1.0.3' to pessimistic constraint '~> 1.0.3'.

This allows automatic compatibility with patch releases (1.0.x) while preventing breaking changes from minor/major updates.

Changes:
- Modified razorpay-pod.podspec dependency constraint
- Bumped version to 1.5.3
- Updated CHANGELOG.md

## Note :- Please follow the below points while attaching test cases document link below:
   ### - If label `Tested` is added then test cases document URL is mandatory.
   ### - Link added should be a valid URL and accessible throughout the org.
   ### - If the branch name contains hotfix / revert by default the BVT workflow check will pass.

| Test Case Document URL                        |
|-----------------------------------------------|
| Please paste test case document link here.... |
