### PR TITLE
release: iOS SDK 1.5.7-rc.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,23 +24,23 @@ let package = Package(
 
         .binaryTarget(
             name: "Razorpay",
-            url: "https://github.com/razorpay/razorpay-pod/releases/download/REL_CORE/Razorpay.xcframework.zip",
-            checksum: "CKSUM_WRAPPER"
+            url: "https://github.com/razorpay/razorpay-pod/releases/download/1.5.7-rc.1/Razorpay.xcframework.zip",
+            checksum: "b54861f87d9b3b7f5a758c38b9a78a0c1d09193d89f3a2f410e4c1f79521a1b5"
         ),
         .binaryTarget(
             name: "RazorpayCore",
-            url: "https://github.com/razorpay/razorpay-pod/releases/download/REL_CORE/RazorpayCore.xcframework.zip",
-            checksum: "CKSUM_CORE"
+            url: "https://github.com/razorpay/razorpay-pod/releases/download/1.5.7-rc.1/RazorpayCore.xcframework.zip",
+            checksum: "d37742f8dfdf76512897d31d08ded951a920733ad58e6b3f8a154e736d16e111"
         ),
         .binaryTarget(
             name: "RazorpayStandard",
-            url: "https://github.com/razorpay/razorpay-pod/releases/download/REL_STANDARD/RazorpayStandard.xcframework.zip",
-            checksum: "CKSUM_STANDARD"
+            url: "https://github.com/razorpay/razorpay-pod/releases/download/1.5.7-rc.1/RazorpayStandard.xcframework.zip",
+            checksum: "432c883637cc47851eb5f2dadacd68d72b466c06cd0c51ac20f27fb37a708975"
         ),
         .binaryTarget(
             name: "RazorpayCustom",
-            url: "https://github.com/razorpay/razorpay-pod/releases/download/REL_CUSTOM/RazorpayCustom.xcframework.zip",
-            checksum: "CKSUM_CUSTOM"
+            url: "https://github.com/razorpay/razorpay-pod/releases/download/1.5.7-rc.1/RazorpayCustom.xcframework.zip",
+            checksum: "fa3bfa829c7025e7822f0574b5f3d0ca727cb4109a3b43de0792943b8559a9a3"
         ),
 
         .testTarget(


### PR DESCRIPTION
Automated SPM release opened by CI.

| | |
|---|---|
| Version | `1.5.7-rc.1` |
| Prerelease | true |
| Re-stamped binaries | Razorpay, RazorpayCore, RazorpayCustom, RazorpayStandard |
| Release | 1.5.7-rc.1 (assets uploaded) |

Merging this brings the stamped `Package.swift` into `refactor/spm-ci-changes`.